### PR TITLE
Strike Price and Energy Market Response

### DIFF
--- a/src/fleets/electric_vehicles_fleet/electric_vehicles_fleet.py
+++ b/src/fleets/electric_vehicles_fleet/electric_vehicles_fleet.py
@@ -596,9 +596,12 @@ class ElectricVehiclesFleet(FleetInterface):
 
             response.dT_hold_limit = None
             response.T_restore     = None
-    
-            response.Strike_price = None
-            response.SOC_cost     = None
+            
+            # TODO: Get SOC_cost and Strike_price API variables not constant over time
+            response.SOC_cost     = 0.2
+            # TODO: Conversion from SOC_cost to Strike_price from "Estimating a DER Device's Strike Price Corresponding..."
+            delta_t = 1
+            response.Strike_price = 0.5*(response.SOC_cost*delta_t/response.C)*response.C
             
             self.SOC = SOC_step
             self.time = t + dt

--- a/src/services/energy_market_service/energy_market_service.py
+++ b/src/services/energy_market_service/energy_market_service.py
@@ -57,11 +57,15 @@ class EnergyMarketService(object):
         p_service_max = np.array([forecast_base[i].P_service_max for i in range(hrs)])   
         p_service_min = np.array([forecast_base[i].P_service_min for i in range(hrs)])  
         p_service = np.array([forecast_base[i].P_service for i in range(hrs)])
+        strike_price = np.array([forecast_base[i].Strike_price for i in range(hrs)])
 
         rt = np.multiply.outer(e_in*0.01, e_out*0.01)*100
         np.fill_diagonal(rt, 0)
+        
+        strike_price = (strike_price*np.ones([hrs,hrs])).T
+        print(strike_price)
  
-        return (rt, p_service_max, p_service_min, p_service)
+        return (rt, p_service_max, p_service_min, p_service, strike_price)
     
     def dispatch_algorithm(self):
         """ 
@@ -70,7 +74,7 @@ class EnergyMarketService(object):
             2. Run the dispatch algorithm to generate P_opt (optimal power profile)
             3. Return P_req = P_opt
         """
-        rt, p_service_max, p_service_min, p_service = self.get_forecast_api_variables()
+        rt, p_service_max, p_service_min, p_service, strike = self.get_forecast_api_variables()
 
         #Constants
         INF = 999999
@@ -96,7 +100,7 @@ class EnergyMarketService(object):
         charged = np.genfromtxt(join(self.base_path, 'ChargeStateOffHourly.csv'), delimiter=',')
         
         # Read price elasitity (strike price) file
-        strike = np.genfromtxt(join(self.base_path, 'StrikePriceHourly.csv'), delimiter=',')
+#        strike = np.genfromtxt(join(self.base_path, 'StrikePriceHourly.csv'), delimiter=',')
         
         # Construct profit table: profit = -price(charge) + eff(i,j)*price(discharge)
         # Fill profit matrix with NaNs


### PR DESCRIPTION
Working on the energy market service. I have calculated the strike price normalized with the capacity of the fleet and with Δt = 1 hour.

I will hopefully finish the PR by the end of the day and post the results in a new issue thread. I am also thinking to provide a price curve in the plots to show how the service creates the requests. Something similar to the plots provided for the artificial inertia service.